### PR TITLE
Set default selected colour to match the colour wheel

### DIFF
--- a/AnneProKeyboard/MainPage.xaml.cs
+++ b/AnneProKeyboard/MainPage.xaml.cs
@@ -62,6 +62,7 @@ namespace AnneProKeyboard
             FindKeyboard();
 
             LoadProfiles();
+            SelectedColour = colourPicker.SelectedColor;
         }
 
         private async void FindKeyboard()


### PR DESCRIPTION
This commit sets SelectedColour to the default set in the .xaml after
the colour wheel component is initialized

This fixes issue #7
